### PR TITLE
Complete the testings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+charset = utf-8

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,7 +9,7 @@ return PhpCsFixer\Config::create()
             "allow_single_line_closure" => true,
             "position_after_functions_and_oop_constructs" => "same",
         ],
-        "array_syntax" => ["syntax" => "short"],
+        "array_syntax" => ["syntax" => "long"],
         "cast_spaces" => true,
         "combine_consecutive_unsets" => true,
         "function_to_constant" => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,40 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        "@PSR1" => true,
+        "@PSR2" => true,
+        "braces" => [
+            "allow_single_line_closure" => true,
+            "position_after_functions_and_oop_constructs" => "same",
+        ],
+        "array_syntax" => ["syntax" => "short"],
+        "cast_spaces" => true,
+        "combine_consecutive_unsets" => true,
+        "function_to_constant" => true,
+        "native_function_invocation" => true,
+        "no_multiline_whitespace_before_semicolons" => true,
+        "no_unused_imports" => true,
+        "no_useless_else" => true,
+        "no_useless_return" => true,
+        "no_whitespace_before_comma_in_array" => true,
+        "no_whitespace_in_blank_line" => true,
+        "non_printable_character" => true,
+        "normalize_index_brace" => true,
+        "ordered_imports" => true,
+        "php_unit_construct" => true,
+        "php_unit_dedicate_assert" => true,
+        "php_unit_fqcn_annotation" => true,
+        "phpdoc_summary" => true,
+        "phpdoc_types" => true,
+        "psr4" => true,
+        "return_type_declaration" => ["space_before" => "none"],
+        "short_scalar_cast" => true,
+        "single_blank_line_before_namespace" => true,
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__ . "/src")
+            ->in(__DIR__ . "/tests")
+    );

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: php
 
-php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - hhvm
-    - 7
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: hhvm
 
 before_install:
     - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "^4.8",
+        "friendsofphp/php-cs-fixer": "^2.2 || ^2.9"
     },
     "autoload": {
         "psr-4": {
@@ -28,6 +29,9 @@
         "psr-4": {
             "ChristianRiesen\\StringHelper\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "fix-syntax": "vendor/bin/php-cs-fixer --diff -v fix"
     },
     "extra": {
         "branch-alias": {

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -2,46 +2,42 @@
 
 namespace ChristianRiesen\StringHelper;
 
-class StringHelper
-{
+class StringHelper {
     /**
-     * Actual string content
+     * Actual string content.
      *
      * @var string
      */
     private $string;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param string $string Content
      */
-    public function __construct($string)
-    {
-        if (!is_string($string)) {
-            throw new \InvalidArgumentException('Expecting string, gotten ' . gettype($string));
+    public function __construct($string) {
+        if (!\is_string($string)) {
+            throw new \InvalidArgumentException('Expecting string, gotten ' . \gettype($string));
         }
 
         $this->string = $string;
     }
 
     /**
-     * Return content
+     * Return content.
      *
      * @return string Content
      */
-    public function get()
-    {
+    public function get() {
         return $this->string;
     }
 
     /**
-     * Return content
+     * Return content.
      *
      * @return string Content
      */
-    public function __toString()
-    {
+    public function __toString() {
         return $this->get();
     }
 
@@ -52,55 +48,51 @@ class StringHelper
      */
 
     /**
-     * Get string length
+     * Get string length.
      *
      * @return integer Length of string
      */
-    public function getLength()
-    {
-        return strlen($this->get());
+    public function getLength() {
+        return \strlen($this->get());
     }
 
     /**
-     * Get word count
+     * Get word count.
      *
      * @return integer Count of words in string
      */
-    public function getWordCount()
-    {
-        return str_word_count($this->get());
+    public function getWordCount() {
+        return \str_word_count($this->get());
     }
 
     /**
-     * Get sentences count
+     * Get sentences count.
      *
      * @return integer Count of sentences in string
      */
-    public function getSentencesCount()
-    {
+    public function getSentencesCount() {
         $string = $this->get();
 
         // Change all endings into dots
-        $string = str_replace(array('!', '?'), '.', $string);
+        $string = \str_replace(['!', '?'], '.', $string);
 
         // Remove non essentials
-        $string = preg_replace('/[^a-zA-Z0-9\.]/', '', $string);
+        $string = \preg_replace('/[^a-zA-Z0-9\.]/', '', $string);
 
         // Remove multiple sentence endings
-        $string = preg_replace('/\.{2,}/', '.', $string);
+        $string = \preg_replace('/\.{2,}/', '.', $string);
 
         // Count sentence endings
-        return substr_count($string, '.');
+        return \substr_count($string, '.');
     }
 
     /**
-     * Get lines count
+     * Get lines count.
      *
      * @return integer Count of lines string
      */
-    public function getLinesCount()
-    {
-        return substr_count($this->get(), "\n");
+    public function getLinesCount() {
+        return \substr_count($this->get(), PHP_EOL);
     }
 
     /**
@@ -110,13 +102,11 @@ class StringHelper
      *
      * @return bool Does this string contain another?
      */
-    public function contains($needle)
-    {
-        if (strpos($this->string, (string) $needle) !== false) {
+    public function contains($needle) {
+        if (\strpos($this->string, (string) $needle) !== false) {
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
     /*
@@ -126,35 +116,32 @@ class StringHelper
      */
 
     /**
-     * Convert everything to upper case
+     * Convert everything to upper case.
      *
      * @return StringHelper
      */
-    public function upper()
-    {
-        return new self(strtoupper($this->get()));
+    public function upper() {
+        return new self(\strtoupper($this->get()));
     }
 
     /**
-     * Convert everything to lower case
+     * Convert everything to lower case.
      *
      * @return StringHelper
      */
-    public function lower()
-    {
-        return new self(strtolower($this->get()));
+    public function lower() {
+        return new self(\strtolower($this->get()));
     }
 
     /**
-     * Cut string down to a specific length
+     * Cut string down to a specific length.
      *
      * @param integer $length Maximum length of new string
      *
      * @return StringHelper
      */
-    public function cut($length)
-    {
-        if (!is_int($length)) {
+    public function cut($length) {
+        if (!\is_int($length)) {
             throw new \InvalidArgumentException('Length to cut must be an integer');
         }
 
@@ -167,6 +154,6 @@ class StringHelper
             return $this;
         }
 
-        return new self(substr($this->get(), 0, $length));
+        return new self(\substr($this->get(), 0, $length));
     }
 }

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -74,7 +74,7 @@ class StringHelper {
         $string = $this->get();
 
         // Change all endings into dots
-        $string = \str_replace(['!', '?'], '.', $string);
+        $string = \str_replace(array('!', '?'), '.', $string);
 
         // Remove non essentials
         $string = \preg_replace('/[^a-zA-Z0-9\.]/', '', $string);

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -31,7 +31,7 @@ class StringHelperTest extends TestCase {
      * @expectedException \InvalidArgumentException
      */
     public function testWrongTypeInConstructorArray() {
-        $t = new StringHelper([1, 2, 3]);
+        $t = new StringHelper(array(1, 2, 3));
     }
 
     /**
@@ -58,11 +58,11 @@ class StringHelperTest extends TestCase {
     }
 
     public function getLengthData() {
-        return [
-            [4, 'test'],
-            [10, '1234567890'],
-            [0, ''],
-        ];
+        return array(
+            array(4, 'test'),
+            array(10, '1234567890'),
+            array(0, ''),
+        );
     }
 
     public function testUpper() {
@@ -88,7 +88,7 @@ class StringHelperTest extends TestCase {
 
     public function testCutWithAlreadyMatchStringLength() {
         $t = new StringHelper('Test Test Test Test');
-        $cut = $t->cut(strlen('Test Test Test Test'));
+        $cut = $t->cut(\strlen('Test Test Test Test'));
 
         $this->assertInstanceOf('ChristianRiesen\StringHelper\StringHelper', $cut);
     }
@@ -121,12 +121,12 @@ class StringHelperTest extends TestCase {
     }
 
     public function getWordCountData() {
-        return [
-            [1, 'one'],
-            [2, 'It\'s two'],
-            [3, 'One two three'],
-            [5, 'One two three. And five.'],
-        ];
+        return array(
+            array(1, 'one'),
+            array(2, 'It\'s two'),
+            array(3, 'One two three'),
+            array(5, 'One two three. And five.'),
+        );
     }
 
     /**
@@ -152,12 +152,12 @@ class StringHelperTest extends TestCase {
     }
 
     public function getSentencesCountData() {
-        return [
-            [1, 'Only a single sentence.'],
-            [1, 'Still, only one; Sentence.'],
-            [2, 'This is two!? Yes it is.'],
-            [2, 'This is two... sentences.'],
-            [1, '"So this is one sentence", he said.'],
-        ];
+        return array(
+            array(1, 'Only a single sentence.'),
+            array(1, 'Still, only one; Sentence.'),
+            array(2, 'This is two!? Yes it is.'),
+            array(2, 'This is two... sentences.'),
+            array(1, '"So this is one sentence", he said.'),
+        );
     }
 }

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -3,51 +3,45 @@
 namespace ChristianRiesen\StringHelper\Tests;
 
 use ChristianRiesen\StringHelper\StringHelper;
+use PHPUnit\Framework\TestCase;
 
-class StringHelperTest extends \PHPUnit_Framework_TestCase
-{
+class StringHelperTest extends TestCase {
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
-    public function testWrongTypeInConstructorBoolean()
-    {
+    public function testWrongTypeInConstructorBoolean() {
         $t = new StringHelper(true);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
-    public function testWrongTypeInConstructorInteger()
-    {
+    public function testWrongTypeInConstructorInteger() {
         $t = new StringHelper((int) 123);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
-    public function testWrongTypeInConstructorFloat()
-    {
+    public function testWrongTypeInConstructorFloat() {
         $t = new StringHelper((float) 1.23);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
-    public function testWrongTypeInConstructorArray()
-    {
-        $t = new StringHelper(array(1, 2, 3));
+    public function testWrongTypeInConstructorArray() {
+        $t = new StringHelper([1, 2, 3]);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
-    public function testWrongTypeInConstructorObject()
-    {
+    public function testWrongTypeInConstructorObject() {
         $t = new StringHelper(new \stdClass());
     }
 
-    public function testSimpleUse()
-    {
+    public function testSimpleUse() {
         $t = new StringHelper('The quick brown fox jumps over the lazy gnome.');
 
         $this->assertEquals('The quick brown fox jumps over the lazy gnome.', $t);
@@ -57,51 +51,62 @@ class StringHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getLengthData
      */
-    public function testLengths($length, $string)
-    {
+    public function testLengths($length, $string) {
         $t = new StringHelper($string);
 
         $this->assertEquals($length, $t->getLength());
     }
 
-    public function getLengthData()
-    {
-        return array(
-            array(4, 'test'),
-            array(10, '1234567890'),
-            array(0, ''),
-        );
+    public function getLengthData() {
+        return [
+            [4, 'test'],
+            [10, '1234567890'],
+            [0, ''],
+        ];
     }
 
-    public function testUpper()
-    {
+    public function testUpper() {
         $t = new StringHelper('Mary and Alice');
         $upper = $t->upper();
 
         $this->assertEquals('MARY AND ALICE', (string) $upper);
     }
 
-    public function testLower()
-    {
+    public function testLower() {
         $t = new StringHelper('Mary and Alice');
         $lower = $t->lower();
 
         $this->assertEquals('mary and alice', (string) $lower);
     }
 
-    public function testCut()
-    {
+    public function testCut() {
         $t = new StringHelper('Test Test Test Test');
         $cut = $t->cut(6);
 
         $this->assertEquals('Test T', (string) $cut);
     }
 
+    public function testCutWithAlreadyMatchStringLength() {
+        $t = new StringHelper('Test Test Test Test');
+        $cut = $t->cut(strlen('Test Test Test Test'));
+
+        $this->assertInstanceOf('ChristianRiesen\StringHelper\StringHelper', $cut);
+    }
+
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
-    public function testCutExceptionSizeZero()
-    {
+    public function testCutWithInvalidLength() {
+        $t = new StringHelper('Test Test Test Test');
+        $cut = $t->cut(0.1);
+
+        $this->assertEquals('Test T', (string) $cut);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCutExceptionSizeZero() {
         $t = new StringHelper('Test Test Test Test');
         $t->cut(0);
     }
@@ -109,41 +114,50 @@ class StringHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getWordCountData
      */
-    public function testWordCount($length, $string)
-    {
+    public function testWordCount($length, $string) {
         $t = new StringHelper($string);
 
         $this->assertEquals($length, $t->getWordCount());
     }
 
-    public function getWordCountData()
-    {
-        return array(
-            array(1, 'one'),
-            array(2, 'It\'s two'),
-            array(3, 'One two three'),
-            array(5, 'One two three. And five.'),
-        );
+    public function getWordCountData() {
+        return [
+            [1, 'one'],
+            [2, 'It\'s two'],
+            [3, 'One two three'],
+            [5, 'One two three. And five.'],
+        ];
     }
 
     /**
      * @dataProvider getSentencesCountData
      */
-    public function testSentencesCount($length, $string)
-    {
+    public function testSentencesCount($length, $string) {
         $t = new StringHelper($string);
 
         $this->assertEquals($length, $t->getSentencesCount());
     }
 
-    public function getSentencesCountData()
-    {
-        return array(
-            array(1, 'Only a single sentence.'),
-            array(1, 'Still, only one; Sentence.'),
-            array(2, 'This is two!? Yes it is.'),
-            array(2, 'This is two... sentences.'),
-            array(1, '"So this is one sentence", he said.'),
-        );
+    public function testGetLinesCount() {
+        $t = new StringHelper('string1'.PHP_EOL.'string2');
+
+        $this->assertEquals(1, $t->getLinesCount());
+    }
+
+    public function testContains() {
+        $t = new StringHelper('string_contains');
+
+        $this->assertTrue($t->contains('contains'));
+        $this->assertFalse($t->contains('no_contains'));
+    }
+
+    public function getSentencesCountData() {
+        return [
+            [1, 'Only a single sentence.'],
+            [1, 'Still, only one; Sentence.'],
+            [2, 'This is two!? Yes it is.'],
+            [2, 'This is two... sentences.'],
+            [1, '"So this is one sentence", he said.'],
+        ];
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 $loader = require __DIR__ . '/../vendor/autoload.php';
 $loader->add("ChristianRiesen\\StringHelper", __DIR__);
 $loader->register();


### PR DESCRIPTION
# Changed log

- add ```.editorconfig``` to unify the white space style.
- set the correct ```.travis.yml``` settings for testing the different PHP version.
According to this [issue](https://github.com/travis-ci/travis-ci/issues/7693), set the dist ```precise``` to complete the PHP 5.3 testing.
- add the ```.php_cs.dist``` to unify the coding style.